### PR TITLE
workaround to stripe api returning success instead of failed

### DIFF
--- a/android/src/main/kotlin/com/dormmom/flutter_stripe_payment/FlutterStripePaymentPlugin.kt
+++ b/android/src/main/kotlin/com/dormmom/flutter_stripe_payment/FlutterStripePaymentPlugin.kt
@@ -260,7 +260,7 @@ class PaymentActivity : Activity()
 
                         val paymentIntent = result.intent
                         val status = paymentIntent.status
-                        if (status == StripeIntent.Status.Succeeded) {
+                        if (status == StripeIntent.Status.Succeeded || status == StripeIntent.Status.RequiresCapture) {
                             // show success UI
                             var paymentResponse = mapOf("status" to "succeeded", "paymentIntentId" to (paymentIntent.id ?: "") )
                             flutterResult?.success(paymentResponse)

--- a/android/src/main/kotlin/com/dormmom/flutter_stripe_payment/FlutterStripePaymentPlugin.kt
+++ b/android/src/main/kotlin/com/dormmom/flutter_stripe_payment/FlutterStripePaymentPlugin.kt
@@ -268,6 +268,12 @@ class PaymentActivity : Activity()
                         else if (StripeIntent.Status.RequiresPaymentMethod == status) {
                             // attempt authentication again or
                             // ask for a new Payment Method
+                            // also id 3d secure fails/declined
+                            paymentIntent.lastPaymentError?.let {
+                                var paymentResponse = mapOf("status" to "failed", "errorMessage" to it.message)
+                                flutterResult?.success(paymentResponse)
+                            }
+                            // FIXME: it should call success anyway or flutter part will wait forever
                         }
                         else if(status == StripeIntent.Status.Canceled)
                         {


### PR DESCRIPTION
when a 3d secure payment requests user interaction, the
stripe api on android will not raise an error as on iOS

the current code makes dart part wait forever
we return instead an error when at least there is a
paymentIntent.lastPaymentError in the response

something needs to be done if paymentIntent.lastPaymentError
is null (when?)